### PR TITLE
Minor spelling and double-listing fixes

### DIFF
--- a/specs/ResourceErrorLogging/Overview.html
+++ b/specs/ResourceErrorLogging/Overview.html
@@ -189,7 +189,7 @@ cite this document as other than work in progress. </p>
 <div class="example">
     <p>
         For example, a user visits <a href="http://example.com">http://example.com</a>, which requests a number of image
-		resoureces, causing the User Agent to
+        resources, causing the User Agent to
         send a HTTP request to the server. The server has a memory bug that causes a random
         set of responses to have a space in the middle of the HTTP response header, like so:
     </p>
@@ -395,11 +395,11 @@ The <a href="#resourceerrorlogging">ResourceErrorLogging</a> interface participa
 <div class="ednote"><div class="ednoteHeader">Editorial note</div>
   <p>
 	The Performance Timeline specification should define a clearData(DOMString entry) method, where entry is a type of PerformanceEntry object buffer that
-	is to be cleared. This method would currently apply to PerformanceResourceTiming, ResourceErrorLogging, and ResourceErrorLogging buffers.
+	is to be cleared. This method would currently apply to PerformanceResourceTiming, ErrorLogging, and ResourceErrorLogging buffers.
   </p>
   <p>
 	The Performance Timeline specification should define a setBufferSize(DOMString entry, unsigned long maxSize) method, where entry is a type of PerformanceEntry object buffer that
-	is to be set. This method would currently apply to PerformanceResourceTiming, ResourceErrorLogging, and ResourceErrorLogging buffers.
+	is to be set. This method would currently apply to PerformanceResourceTiming, ErrorLogging, and ResourceErrorLogging buffers.
   </p>
 </div>
 


### PR DESCRIPTION
s/resoureces/resources; 

ResourceErrorLogging was listed twice in editorial note, one of them should be ErrorLogging.
