### PR TITLE
Added meeting location for June 2016

### DIFF
--- a/meetings/2016/06-westcoast/arrangements.md
+++ b/meetings/2016/06-westcoast/arrangements.md
@@ -4,6 +4,7 @@
 
 Location: Akamai office,
 3355 Scott Blvd, Santa Clara, CA 95054
+[map](https://goo.gl/maps/EqDeKE3z6kG2)
 
 Expected attendees
 

--- a/meetings/2016/06-westcoast/arrangements.md
+++ b/meetings/2016/06-westcoast/arrangements.md
@@ -2,10 +2,8 @@
 
 21 June 2016
 
-Location: Santa Clara, CA (to be confirmed)
-
-If we can't do Santa Clara, we'll do Mountain View.
-
+Location: Akamai office,
+3355 Scott Blvd, Santa Clara, CA 95054
 
 Expected attendees
 
@@ -13,7 +11,7 @@ Expected attendees
 
 * Ilya Grigorik
 * Todd Reifsteck
-* Yoav Weis
+* Yoav Weiss
 * Philippe Le Hegaret
 
 


### PR DESCRIPTION
It is confirmed that we can host the F2F at the Akamai office. Updating the arrangements page accordingly.
