### PR TITLE
Teams are only visible to members of the org, so using public link

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
         <h3>Getting involved</h3>
         <ul>
           <li><a href="https://www.w3.org/webperf/board/">Dashboard</a></li>
-          <li><a href="https://github.com/orgs/w3c/teams/web-performance/repositories">Github</a></li>
+          <li><a href="https://github.com/w3c/web-performance#specifications">Github</a></li>
           <li><a href="https://lists.w3.org/Archives/Public/public-web-perf/">Mailing list</a></li>
           <li><a href="https://www.w3.org/Consortium/cepc/">Code of Conduct</a></li>
         </ul>


### PR DESCRIPTION
The current Github link is only visible to members of the organization.

![](https://ejd.pics/2xj48.png)

I can use another link if you'll like but this one seem most appropriate to me.