### PR TITLE
Remove unmatched </pre> tag

### DIFF
--- a/specs/HAR/Overview.html
+++ b/specs/HAR/Overview.html
@@ -589,14 +589,14 @@ Here is another example with encoded response. The original response is:</p>
 1.5 -&gt; 2.0 (2.0 is not compatible with 1.5)<br />
 </code></p>
 <p>So following construct can be used to detect incompatible version if a tool supports HAR since 1.1.</p>
+<code>
 <div class="dean_ch" style="white-space: wrap;"><span class="kw1">if</span> <span class="br0">&#40;</span>majorVersion != <span class="nu0">1</span> || minorVersion &lt; <span class="nu0">1</span><span class="br0">&#41;</span><br />
 <span class="br0">&#123;</span><br />
 &nbsp; &nbsp; <span class="kw1">throw</span> <span class="st0">&quot;Incompatible version&quot;</span>;<br />
 <span class="br0">&#125;</span></div>
+</code>
 <p>In this example a tool throws an exception if the version is e.g.: 0.8, 0.9, 1.0, but works with 1.1, 1.2, 1.112 etc. Version 2.x would be rejected.</p>
 
-
-</pre>
 
 <h2 id="sec-privacy"><span class="secno">5 </span>Privacy</h2>
 


### PR DESCRIPTION
In the HAR spec there was a closing pre tag without a corresponding open
tag.

I suspect it was really meant to be a code block around the text above.

I found this out when running
`npx prettier --write specs/HAR/Overview.html` told me about the issue.

I'm looking at editing this particular specification, because it
currently starts off with nicely formatted types, but stops at the
`page` object. I will try and fix that later.